### PR TITLE
Split into separate .kitchen.<provider>.yml files for inclusion via `$KITCHEN_LOCAL_YAML`

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -2,15 +2,5 @@
 driver:
   name: docker
 
-provisioner:
-  name: chef_solo
-  require_chef_omnibus: 11.16.4
-  chef_omnibus_install_options: -d /tmp/vagrant-cache/vagrant_omnibus
-
 platforms:
 - name: ubuntu-12.04
-
-suites:
-- name: default
-  run_list: ["recipe[sample-app]"]
-  attributes: {}

--- a/.kitchen.lxc.yml
+++ b/.kitchen.lxc.yml
@@ -1,0 +1,11 @@
+---
+driver:
+  name: vagrant
+
+platforms:
+- name: ubuntu-12.04
+  driver_config:
+    box: fgrehm/precise64-lxc
+    box_url: https://atlas.hashicorp.com/fgrehm/boxes/precise64-lxc/versions/1.2.0/providers/lxc.box
+    customize:
+      cgroup.memory.limit_in_bytes: 128M

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,20 +10,10 @@ provisioner:
 platforms:
 - name: ubuntu-12.04
   driver_config:
-    box: <%= ENV['VAGRANT_DEFAULT_PROVIDER'] == 'lxc' \
-      ? 'fgrehm/precise64-lxc' \
-      : 'chef/ubuntu-12.04-i386' %>
-    box_url: <%= ENV['VAGRANT_DEFAULT_PROVIDER'] == 'lxc' \
-      ? 'https://atlas.hashicorp.com/fgrehm/boxes/precise64-lxc/versions/1.2.0/providers/lxc.box' \
-      : 'https://atlas.hashicorp.com/chef/boxes/ubuntu-12.04-i386/versions/1.0.0/providers/virtualbox.box' %>
+    box: chef/ubuntu-12.04-i386
+    box_url: https://atlas.hashicorp.com/chef/boxes/ubuntu-12.04-i386/versions/1.0.0/providers/virtualbox.box
     customize:
-    <% if ENV['VAGRANT_DEFAULT_PROVIDER'] == 'lxc' %>
-      cgroup.memory.limit_in_bytes: '128M'
-    <% else %>
       memory: 128
-    <% end %>
-
-
 
 suites:
 - name: default

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
   ruby:
     version: 2.1.3
   environment:
-    KITCHEN_YAML: .kitchen.docker.yml
+    KITCHEN_LOCAL_YAML: .kitchen.docker.yml
 
 dependencies:
   override:


### PR DESCRIPTION
Cleaned up the convoluted `.kitchen.yml` and added provider-specific `.kitchen.<provider>.yml` files:

 * `.kitchen.yml` is always considered. It defines the test suites and uses vagrant driver (assuming virtualbox as the default provider)
 * `.kitchen.lxc.yml` still uses the vagrant driver but overrides the basebox and customizations for the vagrant-lxc provider. It is currently used in my [dev-box](https://github.com/tknerr/dev-box/)
 * `.kitchen.docker.yml` uses the docker driver. It is currently used for the CircleCI builds.

To enable a provider specific configuration use the env var, e.g. `KITCHEN_LOCAL_YAML=.kitchen.lxc.yml kitchen test`