### PR TITLE
Update platforms to include Ubuntu 14.04

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -4,3 +4,4 @@ driver:
 
 platforms:
 - name: ubuntu-12.04
+- name: ubuntu-14.04

--- a/.kitchen.lxc.yml
+++ b/.kitchen.lxc.yml
@@ -9,3 +9,9 @@ platforms:
     box_url: https://atlas.hashicorp.com/fgrehm/boxes/precise64-lxc/versions/1.2.0/providers/lxc.box
     customize:
       cgroup.memory.limit_in_bytes: 128M
+- name: ubuntu-14.04
+  driver_config:
+    box: fgrehm/trusty64-lxc
+    box_url: https://atlas.hashicorp.com/fgrehm/boxes/trusty64-lxc/versions/1.2.0/providers/lxc.box
+    customize:
+      cgroup.memory.limit_in_bytes: 128M

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,6 +14,12 @@ platforms:
     box_url: https://atlas.hashicorp.com/chef/boxes/ubuntu-12.04-i386/versions/1.0.0/providers/virtualbox.box
     customize:
       memory: 128
+- name: ubuntu-14.04
+  driver_config:
+    box: chef/ubuntu-14.04-i386
+    box_url: https://atlas.hashicorp.com/chef/boxes/ubuntu-14.04-i386/versions/1.0.0/providers/virtualbox.box
+    customize:
+      memory: 128
 
 suites:
 - name: default

--- a/Berksfile
+++ b/Berksfile
@@ -1,12 +1,3 @@
 source "https://supermarket.chef.io"
 
-#
-# dependencies on "application cookbooks"
-#
-cookbook "apache2",  "1.10.4"
-cookbook "apt",      "2.4.0"
-
-#
-# dependency on self
-#
-cookbook "sample-app", path: "."
+metadata

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -4,14 +4,12 @@ DEPENDENCIES
     metadata: true
 
 GRAPH
-  apache2 (1.10.4)
+  apache2 (3.0.0)
     iptables (>= 0.0.0)
     logrotate (>= 0.0.0)
-    pacman (>= 0.0.0)
-  apt (2.4.0)
+  apt (2.6.1)
   iptables (0.14.1)
   logrotate (1.7.0)
-  pacman (1.1.1)
   sample-app (0.2.1)
-    apache2 (= 1.10.4)
-    apt (= 2.4.0)
+    apache2 (= 3.0.0)
+    apt (= 2.6.1)

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,8 +1,7 @@
 DEPENDENCIES
-  apache2 (= 1.10.4)
-  apt (= 2.4.0)
   sample-app
     path: .
+    metadata: true
 
 GRAPH
   apache2 (1.10.4)
@@ -16,6 +15,3 @@ GRAPH
   sample-app (0.2.1)
     apache2 (= 1.10.4)
     apt (= 2.4.0)
-    iptables (= 0.14.1)
-    logrotate (= 1.7.0)
-    pacman (= 1.1.1)

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ end
 
 desc "run foodcritic lint checks"
 task :foodcritic do
-  sh "foodcritic -f any -t ~FC007 ."
+  sh "foodcritic -f any ."
 end
 
 desc "check code style with tailor"

--- a/circle.yml
+++ b/circle.yml
@@ -14,5 +14,5 @@ dependencies:
 test:
   override:
     - bundle exec rake test
-    - bundle exec kitchen verify -c:
+    - bundle exec kitchen verify:
         timeout: 900

--- a/circle.yml
+++ b/circle.yml
@@ -14,5 +14,5 @@ dependencies:
 test:
   override:
     - bundle exec rake test
-    - bundle exec kitchen verify:
+    - bundle exec kitchen verify -c:
         timeout: 900

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,5 +6,5 @@ description      "A minimal sample application cookbook"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.2.1"
 
-depends "apache2", "1.10.4"
-depends "apt", "2.4.0"
+depends "apache2", "3.0.0"
+depends "apt", "2.6.1"

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,10 +6,5 @@ description      "A minimal sample application cookbook"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.2.1"
 
-
-# read resolved dependencies from Berksfile.lock, i.e. lock the complete dependency graph
-locked_deps = IO.read('Berksfile.lock').lines.drop_while { |l| l != "GRAPH\n" }
-locked_deps.keep_if { |line| line.match(/^\s{2}\w+\s\(.*\)/) }.each do |entry|
-  dep_name, dep_version = entry.strip.match(/^(\w+)\s\((.*)\)/).captures
-  depends(dep_name, dep_version) unless dep_name.eql? name
-end
+depends "apache2", "1.10.4"
+depends "apt", "2.4.0"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,11 @@ package "net-tools"
 node.set['apache']['default_site_enabled'] = true
 include_recipe "apache2"
 
+# ensure the service is started
+service "apache2" do
+  action [:enable, :start]
+end
+
 # workaround for CHEF-4753
 if Chef::Config['data_bag_path'].is_a? Array
   Chef::Config['data_bag_path'] = Chef::Config['data_bag_path'].first
@@ -29,7 +34,7 @@ rescue => e
   log "can not load data_bag: #{e.message}"
 end
 
-# deploy sample html page 
+# deploy sample html page
 template "/var/www/sample.html" do
   source "sample.html.erb"
   owner node['apache']['user']

--- a/test/chefspec/default_spec.rb
+++ b/test/chefspec/default_spec.rb
@@ -4,6 +4,8 @@ describe "sample-app::default" do
 
   before do
     stub_data_bag("yummy").and_return([])
+    stub_command("/usr/sbin/apache2 -t").and_return("Syntax OK")
+    stub_command("/usr/sbin/httpd -t").and_return("Syntax OK")
   end
 
   context "on ubuntu systems" do
@@ -24,7 +26,7 @@ describe "sample-app::default" do
   end
 
   context "when 'words_of_wisdom' are set" do
-    subject { chef_run { 
+    subject { chef_run {
       node.set['sample_app']['words_of_wisdom'] = "no cats today :-("
     }}
     it { should render_file("/var/www/sample.html").with_content("no cats today :-(") }


### PR DESCRIPTION
This PR 
 
 * adds Ubuntu 14.04 as a platform for all providers (docker, lxc and virtualbox)
 * updates to latest version of apache2 and apt cookbooks
 * ensures that apache2 is really running
 * enables concurrency for the kitchenci test runs on circleci

P.S.: it also reverts d0e2cf15255e1cd85231a38d0650547ba1a32fe2 which seemed to work fine at first, but then noticed that it would not alow for updating a cookbook dependendency without removing Berksfile.lock first.

