### PR TITLE
back to ubuntu boxes now that test-kitchen/busser-serverspec#22 is fixed

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,16 +10,16 @@ provisioner:
 platforms:
 - name: ubuntu-12.04
   driver_config:
-    box: chef/ubuntu-12.04-i386
-    box_url: https://atlas.hashicorp.com/chef/boxes/ubuntu-12.04-i386/versions/1.0.0/providers/virtualbox.box
+    box: ubuntu/precise32
+    box_url: https://atlas.hashicorp.com/ubuntu/boxes/precise32/versions/12.04.4/providers/virtualbox.box
     customize:
       memory: 128
 - name: ubuntu-14.04
   driver_config:
-    box: chef/ubuntu-14.04
-    box_url: https://atlas.hashicorp.com/chef/boxes/ubuntu-14.04/versions/1.0.0/providers/virtualbox.box
+    box: ubuntu/trusty64
+    box_url: https://atlas.hashicorp.com/ubuntu/boxes/trusty64/versions/14.04/providers/virtualbox.box
     customize:
-      memory: 128
+      memory: 256
 
 suites:
 - name: default


### PR DESCRIPTION
Not sure yet. We could go back to the "stock" ubuntu boxes now that test-kitchen/busser-serverspec#22 is fixed.

However:

 * the ubuntu/trusty64 box is not provisionerless => will reinstall Chef on top of Chef 11.8.2 which is included in the box
 * the ubuntu/trusty64 box needs more memory than the chef/ubuntu-12.04 box

So I'll probably just be glad that it's fixed, but see not advantage in goint back to the ubuntu boxes...