### PR TITLE
Remove redundant service (start, enabled) resource declaration

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -14,11 +14,6 @@ include_recipe 'apt'
 node.set['apache']['default_site_enabled'] = true
 include_recipe 'apache2'
 
-# ensure the service is started
-service 'apache2' do
-  action [:enable, :start]
-end
-
 # workaround for CHEF-4753
 if Chef::Config['data_bag_path'].is_a? Array
   Chef::Config['data_bag_path'] = Chef::Config['data_bag_path'].first


### PR DESCRIPTION
This is redundant as the apache cookbook already does this.

For some reason I introduced it in 68c275e in the context of #10, where I believed that it would fix a the broken docker-based integration tests.

Not only is it redundant, it's also confusing because in the chefspec tests we assert that it would start/enable the 'httpd' service, but actually we hardcode it here as 'apache2' (which, if we actually had run the integration tests on centos would have probably failed!) 

So I removed it and the docker based tests are still running. Must have been a false conclusion in the first place... ;-)