### PR TITLE
Update all gems to their latest version / update to Chef 12.4.1

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -5,7 +5,7 @@ driver:
 driver_config:
   provision_command:
     - apt-get update && apt-get install net-tools
-    - curl -L https://www.opscode.com/chef/install.sh | bash -s -- -v 12.3.0
+    - curl -L https://www.opscode.com/chef/install.sh | bash -s -- -v 12.4.1
     - env GEM_HOME=/tmp/verifier/gems GEM_PATH=/tmp/verifier/gems GEM_CACHE=/tmp/verifier/gems/cache /opt/chef/embedded/bin/gem install thor busser busser-serverspec serverspec bundler && chown -R kitchen:kitchen /tmp/verifier
   require_chef_omnibus: false
   use_sudo: false

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,7 +4,7 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: 12.3.0
+  require_chef_omnibus: 12.4.1
   chef_omnibus_install_options: -d /tmp/vagrant-cache/vagrant_omnibus
 
 platforms:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 # 0.3.0 (unreleased)
 
 * test / toolchain updates:
-  * Update to Chef 12.3.0
+  * Update to Chef 12.4.1
+  * Update gem dependencies to their latest version
 
 # 0.2.2 (April 15, 2015)
 

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ end
 group :integration do
   gem 'vagrant-wrapper', '2.0.2'
   gem 'test-kitchen', '1.4.2'
-  gem 'kitchen-docker', '2.1.0'
+  gem 'kitchen-docker', '2.2.0'
   gem 'kitchen-vagrant', '0.18.0'
   gem 'serverspec', '2.21.1'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'stove', '3.2.6'
 group :test do
   gem 'foodcritic', '4.0.0'
   gem 'rubocop', '0.30.1'
-  gem 'chefspec', '4.2.0', git: 'https://github.com/tknerr/chefspec.git', ref: 'patch-1'
+  gem 'chefspec', '4.3.0'
 end
 
 group :integration do

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ end
 group :integration do
   gem 'vagrant-wrapper', '2.0.2'
   gem 'test-kitchen', '1.4.2'
-  gem 'kitchen-docker', '2.3.0'
+  gem 'kitchen-docker', '2.1.0'
   gem 'kitchen-vagrant', '0.18.0'
   gem 'serverspec', '2.21.1'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,19 +1,19 @@
 source 'https://rubygems.org'
 
-gem 'chef', '12.3.0'
-gem 'berkshelf', '3.2.3'
-gem 'stove', '3.2.6'
+gem 'chef', '12.4.1'
+gem 'berkshelf', '3.2.4'
+gem 'stove', '3.2.7'
 
 group :test do
   gem 'foodcritic', '4.0.0'
-  gem 'rubocop', '0.30.1'
+  gem 'rubocop', '0.33.0'
   gem 'chefspec', '4.3.0'
 end
 
 group :integration do
   gem 'vagrant-wrapper', '2.0.2'
   gem 'test-kitchen', '1.4.2'
-  gem 'kitchen-docker', '2.1.0'
-  gem 'kitchen-vagrant', '0.17.0'
-  gem 'serverspec', '2.14.0'
+  gem 'kitchen-docker', '2.3.0'
+  gem 'kitchen-vagrant', '0.18.0'
+  gem 'serverspec', '2.21.1'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ end
 group :integration do
   gem 'vagrant-wrapper', '2.0.2'
   gem 'test-kitchen', '1.4.2'
-  gem 'kitchen-docker', '2.2.0'
+  gem 'kitchen-docker', '2.1.0'
   gem 'kitchen-vagrant', '0.18.0'
   gem 'serverspec', '2.21.1'
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@ Vagrant.configure('2') do |config|
   # enable cachier
   #config.cache.scope = :box
   # the Chef version to use
-  config.omnibus.chef_version = '12.3.0'
+  config.omnibus.chef_version = '12.4.1'
   # enable berkshelf plugin
   config.berkshelf.enabled = true
 


### PR DESCRIPTION
All gems in the Gemfile have been updated to their latest version, except for kitchen-docker which currently breaks the CircleCI build (see portertech/kitchen-docker#160).

Also, Chef has been consistently updated to 12.4.1 (Gemfile, .kitchen.yml, Vagrantfile)