### PR TITLE
Add ChefDK 0.13 compatibility

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,7 +19,7 @@ Style/MultilineBlockLayout:
   Exclude:
     - 'test/**/*.rb'
 
-Style/SingleSpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
   Enabled: false
 
 AllCops:

--- a/Gemfile
+++ b/Gemfile
@@ -1,18 +1,18 @@
 source 'https://rubygems.org'
 
-gem 'chef', '12.4.1'
-gem 'berkshelf', '4.0.1'
+gem 'chef', '12.9.41'
+gem 'berkshelf', '4.3.2'
 gem 'stove', '3.2.7'
 
 group :test do
-  gem 'foodcritic', '4.0.0'
-  gem 'rubocop', '0.33.0'
-  gem 'chefspec', '4.3.0'
+  gem 'foodcritic', '6.1.1'
+  gem 'rubocop', '0.37.2'
+  gem 'chefspec', '4.6.1'
 end
 
 group :integration do
-  gem 'test-kitchen', '1.4.2'
+  gem 'test-kitchen', '1.7.3'
   gem 'kitchen-docker', '2.1.0'
-  gem 'kitchen-vagrant', '0.18.0'
-  gem 'serverspec', '2.21.1'
+  gem 'kitchen-vagrant', '0.20.0'
+  gem 'serverspec', '2.31.1'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,7 @@ task :test => [:foodcritic, :codestyle, :spec]
 desc 'release the cookbook (metadata, tag, push)'
 task :release do
   print 'This will create and push a tag with the version from `metadata.rb`. Continue? [y/n] '
-  if (STDIN.gets.chomp).match(/^[yY][eE]?[sS]?$/)
+  if STDIN.gets.chomp =~ /^[yY][eE]?[sS]?$/
     sh 'stove --log-level info'
   else
     puts 'release aborted'

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   services:
     - docker
   ruby:
-    version: 2.1.5
+    version: 2.1.8
   environment:
     VAGRANT_DEFAULT_PROVIDER: docker
 

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,9 @@ dependencies:
   cache_directories:
     - ~/.vagrant.d
   pre:
+    - bundle -v
+    - gem -v
+    - ruby -v
     - wget https://releases.hashicorp.com/vagrant/1.8.1/vagrant_1.8.1_x86_64.deb
     - sudo dpkg -i vagrant_1.8.1_x86_64.deb
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -10,9 +10,7 @@ dependencies:
   cache_directories:
     - ~/.vagrant.d
   pre:
-    - bundle -v
-    - gem -v
-    - ruby -v
+    - gem update --system '2.6.3'
     - wget https://releases.hashicorp.com/vagrant/1.8.1/vagrant_1.8.1_x86_64.deb
     - sudo dpkg -i vagrant_1.8.1_x86_64.deb
   override:

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,6 +5,8 @@ license          'All rights reserved'
 description      'A minimal sample application cookbook'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.2.1'
+issues_url       'https://github.com/tknerr/sample-toplevel-cookbook/issues'
+source_url       'https://github.com/tknerr/sample-toplevel-cookbook'
 
 depends 'apache2', '3.0.1'
 depends 'apt', '2.7.0'


### PR DESCRIPTION
This PR adds compatibility with ChefDK 0.13.21:
- updates Gemfile with the gem versions shipped in ChefDK
- adds fixes for newly introduced foodcritic rules (issues_url and source_url in metadata)
- adds compatibility with latest rubocop and fixes for newly introduced rule
